### PR TITLE
prac02: Remove initial "number-of-lines"

### DIFF
--- a/2017/problems/prac02.in
+++ b/2017/problems/prac02.in
@@ -1,4 +1,3 @@
-3
 Mitchell coding
 Danese testing
 Larry debugging

--- a/2017/problems/prac02.in2
+++ b/2017/problems/prac02.in2
@@ -1,4 +1,3 @@
-4
 Sherry hosting
 Jason judging
 Greg recording

--- a/2017/solutions/prac02.c
+++ b/2017/solutions/prac02.c
@@ -1,15 +1,22 @@
 #include <stdio.h>
+
+/*
+ * A line contains up to 80 characters, including the newline.  fgets()
+ * adds a null byte to terminate the string.
+ *
+ * Each line contains two words separated by a space.  sscanf() also adds a
+ * null byte to terminate the string.
+ */
  
-int main(int argc, char **argv) {
-    int numCases;
-    char noun[99 + 1]; /* + '\0' */
-    char verb[99 + 1]; /* + '\0' */
+int main(int argc, char **argv)
+{
+    char line[80 + 1], noun[80 + 1], verb[80 + 1];
+    int items;
  
-    scanf("%d", &numCases);
-    while (numCases) {
-        --numCases;
-        scanf("%s %s", noun, verb);
-        printf("%s is %s today!\n", noun, verb);
+    while (fgets(line, sizeof(line), stdin)) {
+	items = sscanf(line, "%80s %80s", noun, verb);
+	if (items == 2)
+	    printf("%s is %s today!\n", noun, verb);
     }
     return 0;
 }

--- a/2017/solutions/prac02.cpp
+++ b/2017/solutions/prac02.cpp
@@ -3,15 +3,12 @@
  
 using namespace std;
  
-int main(int argc, char **argv) {
-    int numCases;
-    string name, verb;
-    cin >> numCases;
-    while (numCases) {
-        --numCases;
-        cin >> name >> verb;
-        cout << name << " is " << verb << " today!" << endl;
+int main(int argc, char **argv)
+{
+    string noun, verb;
+
+    while (cin >> noun >> verb) {
+        cout << noun << " is " << verb << " today!" << endl;
     }
     return 0;
 }
-

--- a/2017/solutions/prac02.java
+++ b/2017/solutions/prac02.java
@@ -5,14 +5,11 @@ public class prac02 {
         BufferedReader reader
             = new BufferedReader(new InputStreamReader(System.in));
  
-        int numCases = Integer.parseInt(reader.readLine());
-
-
-        while (numCases > 0) {
-            --numCases;
-            String line[] = reader.readLine().trim().split("\\s+");
-            String noun = line[0];
-            String verb = line[1];
+        String line = null;
+        while ((line = reader.readLine()) != null) {
+            String words[] = line.trim().split("\\s+");
+            String noun = words[0];
+            String verb = words[1];
             System.out.println(noun + " is " + verb + " today!");
         }
     }

--- a/2017/solutions/prac02.py2
+++ b/2017/solutions/prac02.py2
@@ -1,13 +1,7 @@
 import sys
 
-lines = sys.stdin.readlines()
-num_cases = int(lines[0])
-
-case = 1
-while case < num_cases + 1:
-    line = lines[case].split()
-    noun = line[0]
-    verb = line[1]
+for line in sys.stdin:
+    words = line.split()
+    noun = words[0]
+    verb = words[1]
     print "%s is %s today!" % (noun, verb)
-    case = case + 1
-

--- a/2017/solutions/prac02.py3
+++ b/2017/solutions/prac02.py3
@@ -1,13 +1,7 @@
 import sys
 
-lines = sys.stdin.readlines()
-num_cases = int(lines[0])
-
-case = 1
-while case < num_cases + 1:
-    line = lines[case].split()
-    noun = line[0]
-    verb = line[1]
+for line in sys.stdin:
+    words = line.split()
+    noun = words[0]
+    verb = words[1]
     print("%s is %s today!" % (noun, verb))
-    case = case + 1
-


### PR DESCRIPTION
Proposed problem description update (I can't update the PDF directly):

  The input contains zero or more lines of at most 80 characters, including
  a trailing newline.  Each line contains two words separated by a space.

  <Remove "3" from the Sample Input box>

Update the input data and the sample solutions to match.

Note that the C solution uses fgets() and sscanf("%80s") instead of the
original scanf("%s").  This imposes arbitrary limits on the line and word
length, but makes it safe from buffer overruns.